### PR TITLE
Add Annotation component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "react": "^18.2.0"
+        "@types/react-dom": "^18.0.10",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.5",
@@ -36,7 +38,6 @@
         "eslint-plugin-react": "^7.31.11",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "^0.6.8",
-        "react-dom": "^18.2.0",
         "tslib": "^2.4.1",
         "typescript": "^4.9.3",
         "vite": "^4.0.3",
@@ -5937,8 +5938,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -5950,18 +5950,24 @@
       "version": "18.0.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
       "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-dom": {
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
+      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -9391,8 +9397,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/currently-unhandled": {
       "version": "0.4.1",
@@ -16797,7 +16802,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -17972,7 +17976,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -25747,8 +25750,7 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -25760,18 +25762,24 @@
       "version": "18.0.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
       "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
+    "@types/react-dom": {
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
+      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -28472,8 +28480,7 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -34265,7 +34272,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -35176,7 +35182,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "dist"
   ],
   "dependencies": {
-    "react": "^18.2.0"
+    "@types/react-dom": "^18.0.10",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",
@@ -59,7 +61,6 @@
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "^0.6.8",
-    "react-dom": "^18.2.0",
     "tslib": "^2.4.1",
     "typescript": "^4.9.3",
     "vite": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build": "vite build",
     "lint": "npx eslint src --ext .js,.jsx,.ts,.tsx",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "prepare": "npm run build"
   },
   "main": "dist/mapkit-react.umd.js",
   "module": "dist/mapkit-react.js",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "build": "vite build",
     "lint": "npx eslint src --ext .js,.jsx,.ts,.tsx",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "prepare": "npm run build"
+    "build-storybook": "build-storybook"
   },
   "main": "dist/mapkit-react.umd.js",
   "module": "dist/mapkit-react.js",

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -2,7 +2,7 @@ import {
   useContext,
   useEffect,
   useState,
-  useRef,
+  useMemo,
 } from 'react';
 import { createPortal } from 'react-dom';
 import MapContext from '../context/MapContext';
@@ -22,17 +22,16 @@ export default function Annotation({
   children,
 }: AnnotationProps) {
   const [annotation, setAnnotation] = useState<mapkit.Annotation | null>(null);
-  const contentRef = useRef<HTMLDivElement>(document.createElement('div'));
+  const contentEl = useMemo<HTMLDivElement>(() => document.createElement('div'), []);
   const map = useContext(MapContext);
 
   // Coordinates
   useEffect(() => {
     if (map === null) return undefined;
-    if (!contentRef.current) return undefined;
 
     const a = new mapkit.Annotation(
       new mapkit.Coordinate(latitude, longitude),
-      () => contentRef.current,
+      () => contentEl,
     );
     map.addAnnotation(a);
     setAnnotation(a);
@@ -40,7 +39,7 @@ export default function Annotation({
     return () => {
       map.removeAnnotation(a);
     };
-  }, [map, contentRef, latitude, longitude]);
+  }, [map, latitude, longitude]);
 
   // Simple values properties
   const properties = {
@@ -74,5 +73,5 @@ export default function Annotation({
     }, [annotation, handler]);
   });
 
-  return contentRef.current && createPortal(children, contentRef.current);
+  return createPortal(children, contentEl);
 }

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,0 +1,79 @@
+import {
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import MapContext from '../context/MapContext';
+import AnnotationProps from './AnnotationProps';
+
+export default function Annotation({
+  latitude,
+  longitude,
+
+  title = '',
+  subtitle = '',
+  accessibilityLabel = null,
+
+  selected = undefined,
+  onSelect = undefined,
+  onDeselect = undefined,
+  children,
+}: AnnotationProps) {
+  const [annotation, setAnnotation] = useState<mapkit.Annotation | null>(null);
+  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
+  const map = useContext(MapContext);
+
+  // Coordinates
+  useEffect(() => {
+    if (map === null) return undefined;
+
+    const el = document.createElement('div');
+    el.id = 'annotation-content';
+    setContentEl(el);
+    const a = new mapkit.Annotation(
+      new mapkit.Coordinate(latitude, longitude),
+      () => el,
+    );
+    map.addAnnotation(a);
+    setAnnotation(a);
+
+    return () => {
+      map.removeAnnotation(a);
+    };
+  }, [map, latitude, longitude]);
+
+  // Simple values properties
+  const properties = {
+    title,
+    subtitle,
+    accessibilityLabel,
+
+    selected,
+  };
+  Object.entries(properties).forEach(([propertyName, prop]) => {
+    useEffect(() => {
+      if (!annotation) return;
+      // @ts-ignore
+      annotation[propertyName] = prop;
+    }, [annotation, prop]);
+  });
+
+  // Events
+  const events = [
+    { name: 'select', handler: onSelect },
+    { name: 'deselect', handler: onDeselect },
+  ] as const;
+  events.forEach(({ name, handler }) => {
+    useEffect(() => {
+      if (!annotation || !handler) return undefined;
+
+      const handlerWithoutParameters = () => handler();
+
+      annotation.addEventListener(name, handlerWithoutParameters);
+      return () => annotation.removeEventListener(name, handlerWithoutParameters);
+    }, [annotation, handler]);
+  });
+
+  return contentEl && createPortal(children, contentEl);
+}

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -29,7 +29,6 @@ export default function Annotation({
     if (map === null) return undefined;
 
     const el = document.createElement('div');
-    el.id = 'annotation-content';
     setContentEl(el);
     const a = new mapkit.Annotation(
       new mapkit.Coordinate(latitude, longitude),

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -2,6 +2,7 @@ import {
   useContext,
   useEffect,
   useState,
+  useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
 import MapContext from '../context/MapContext';
@@ -21,18 +22,17 @@ export default function Annotation({
   children,
 }: AnnotationProps) {
   const [annotation, setAnnotation] = useState<mapkit.Annotation | null>(null);
-  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement>(document.createElement('div'));
   const map = useContext(MapContext);
 
   // Coordinates
   useEffect(() => {
     if (map === null) return undefined;
+    if (!contentRef.current) return undefined;
 
-    const el = document.createElement('div');
-    setContentEl(el);
     const a = new mapkit.Annotation(
       new mapkit.Coordinate(latitude, longitude),
-      () => el,
+      () => contentRef.current,
     );
     map.addAnnotation(a);
     setAnnotation(a);
@@ -40,7 +40,7 @@ export default function Annotation({
     return () => {
       map.removeAnnotation(a);
     };
-  }, [map, latitude, longitude]);
+  }, [map, contentRef, latitude, longitude]);
 
   // Simple values properties
   const properties = {
@@ -74,5 +74,5 @@ export default function Annotation({
     }, [annotation, handler]);
   });
 
-  return contentEl && createPortal(children, contentEl);
+  return contentRef.current && createPortal(children, contentRef.current);
 }

--- a/src/components/AnnotationProps.tsx
+++ b/src/components/AnnotationProps.tsx
@@ -33,12 +33,12 @@ export default interface AnnotationProps {
   selected?: boolean;
 
   /**
-   * Event fired when the marker is selected.
+   * Event fired when the annotation is selected.
    */
   onSelect?: () => void;
 
   /**
-   * Event fired when the marker is deselected.
+   * Event fired when the annotation is deselected.
    */
   onDeselect?: () => void;
 

--- a/src/components/AnnotationProps.tsx
+++ b/src/components/AnnotationProps.tsx
@@ -1,0 +1,49 @@
+export default interface AnnotationProps {
+  /**
+   * The latitude in degrees.
+   */
+  latitude: number;
+
+  /**
+   * The longitude in degrees.
+   */
+  longitude: number;
+
+  /**
+   * The text to display in the annotation’s callout.
+   * @see {@link https://developer.apple.com/documentation/mapkitjs/annotation/2973835-title}
+   */
+  title?: string;
+
+  /**
+   * The text to display as a subtitle on the second line of an annotation’s callout.
+   * @see {@link https://developer.apple.com/documentation/mapkitjs/annotation/2973834-subtitle}
+   */
+  subtitle?: string;
+
+  /**
+   * Accessibility text for the annotation.
+   * @see {@link https://developer.apple.com/documentation/mapkitjs/annotation/2973814-accessibilitylabel}
+   */
+  accessibilityLabel?: string | null;
+
+  /**
+   * A Boolean value that determines whether the map displays the annotation in a selected state.
+   */
+  selected?: boolean;
+
+  /**
+   * Event fired when the marker is selected.
+   */
+  onSelect?: () => void;
+
+  /**
+   * Event fired when the marker is deselected.
+   */
+  onDeselect?: () => void;
+
+  /**
+   * React children to render inside the annotation.
+   */
+  children?: React.ReactNode;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export { default as Map } from './components/Map';
 export type { default as MapProps } from './components/MapProps';
 export { default as Marker } from './components/Marker';
 export type { default as MarkerProps } from './components/MarkerProps';
+export { default as Annotation } from './components/Annotation';
+export type { default as AnnotationProps } from './components/AnnotationProps';
 export {
   ColorScheme, MapType, Distances, LoadPriority, FeatureVisibility,
 } from './util/parameters';

--- a/src/stories/Annotation.stories.tsx
+++ b/src/stories/Annotation.stories.tsx
@@ -7,16 +7,17 @@ import { CoordinateRegion, FeatureVisibility } from '../util/parameters';
 
 const token = process.env.STORYBOOK_MAPKIT_JS_TOKEN!;
 
+// SVG from https://webkul.github.io/vivid
 function CustomMarker() {
   return (
     <svg width="24px" height="24px" viewBox="-4 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg">
-      <g id="Vivid.JS" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-        <g id="Vivid-Icons" transform="translate(-125.000000, -643.000000)">
-          <g id="Icons" transform="translate(37.000000, 169.000000)">
-            <g id="map-marker" transform="translate(78.000000, 468.000000)">
+      <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+        <g transform="translate(-125.000000, -643.000000)">
+          <g transform="translate(37.000000, 169.000000)">
+            <g transform="translate(78.000000, 468.000000)">
               <g transform="translate(10.000000, 6.000000)">
                 <path d="M14,0 C21.732,0 28,5.641 28,12.6 C28,23.963 14,36 14,36 C14,36 0,24.064 0,12.6 C0,5.641 6.268,0 14,0 Z" id="Shape" fill="#FF6E6E" />
-                <circle id="Oval" fill="#0C0058" fillRule="nonzero" cx="14" cy="14" r="7" />
+                <circle fill="#0C0058" fillRule="nonzero" cx="14" cy="14" r="7" />
               </g>
             </g>
           </g>

--- a/src/stories/Annotation.stories.tsx
+++ b/src/stories/Annotation.stories.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react';
+import { ComponentMeta, Story } from '@storybook/react';
+
+import Map from '../components/Map';
+import Annotation from '../components/Annotation';
+import { CoordinateRegion, FeatureVisibility } from '../util/parameters';
+
+const token = process.env.STORYBOOK_MAPKIT_JS_TOKEN!;
+
+function CustomMarker() {
+  return (
+    <svg width="24px" height="24px" viewBox="-4 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg">
+      <g id="Vivid.JS" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+        <g id="Vivid-Icons" transform="translate(-125.000000, -643.000000)">
+          <g id="Icons" transform="translate(37.000000, 169.000000)">
+            <g id="map-marker" transform="translate(78.000000, 468.000000)">
+              <g transform="translate(10.000000, 6.000000)">
+                <path d="M14,0 C21.732,0 28,5.641 28,12.6 C28,23.963 14,36 14,36 C14,36 0,24.064 0,12.6 C0,5.641 6.268,0 14,0 Z" id="Shape" fill="#FF6E6E" />
+                <circle id="Oval" fill="#0C0058" fillRule="nonzero" cx="14" cy="14" r="7" />
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+const enumArgType = (e: object) => ({
+  options: Object.values(e).filter((x) => typeof x === 'string'),
+  mapping: e,
+});
+export default {
+  title: 'Components/Annotation',
+  component: Annotation,
+  args: {},
+  argTypes: {
+    subtitleVisibility: enumArgType(FeatureVisibility),
+    titleVisibility: enumArgType(FeatureVisibility),
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Annotation>;
+
+type MarkerProps = React.ComponentProps<typeof Annotation>;
+
+const Template: Story<MarkerProps> = (args) => {
+  const initialRegion: CoordinateRegion = useMemo(() => ({
+    centerLatitude: 48,
+    centerLongitude: 14,
+    latitudeDelta: 22,
+    longitudeDelta: 55,
+  }), []);
+  return (
+    <Map token={token} initialRegion={initialRegion}>
+      <Annotation {...args}>
+        <CustomMarker />
+      </Annotation>
+    </Map>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = { latitude: 46.52, longitude: 6.57 };

--- a/support.md
+++ b/support.md
@@ -215,9 +215,6 @@ To call methods on the `mapkit.Map` object, you can use the reference exposed by
 
 ## `mapkit.Annotation`
 
-> **Note**
-> Only `MarkerAnnotation` can currently be used with mapkit-react. Annotations using a custom DOM element are not supported.
-
 ### Constructor parameters
 
 | Feature                                           | Supported |
@@ -229,7 +226,7 @@ To call methods on the `mapkit.Map` object, you can use the reference exposed by
 | AnnotationConstructorOptions.draggable            | ❌        |
 | AnnotationConstructorOptions.visible              | ❌        |
 | AnnotationConstructorOptions.enabled              | ❌        |
-| AnnotationConstructorOptions.selected             | ❌        |
+| AnnotationConstructorOptions.selected             | ✅        |
 | AnnotationConstructorOptions.calloutEnabled       | ❌        |
 | AnnotationConstructorOptions.animates             | ❌        |
 | AnnotationConstructorOptions.appearanceAnimation  | ❌        |


### PR DESCRIPTION
Adds `Annotation` component for rendering custom React elements as the annotation content.

```tsx
<Map>
  <Annotation latitude={46.52} longitude={6.57}>
    <div>Some content</div>
  </Annotation>
</Map>
```

Not sure if this is inline with how you'd like to support annotations. I just had a use case for rendering custom markers and thought I'd open a PR upstream. Happy to iterate on this if you're down!