### PR TITLE
Add `load` prop to Map

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -43,6 +43,7 @@ function forwardMapkitEvent<E>(
 const Map = React.forwardRef<mapkit.Map | null, React.PropsWithChildren<MapProps>>(({
   children = undefined,
 
+  load: customLoad,
   token,
 
   colorScheme = ColorScheme.Light,
@@ -94,7 +95,8 @@ const Map = React.forwardRef<mapkit.Map | null, React.PropsWithChildren<MapProps
 
   // Load the map
   useEffect(() => {
-    load(token).then(() => {
+    const loadMap = typeof customLoad === 'function' ? customLoad : load;
+    loadMap(token).then(() => {
       if (exists.current) return;
       const options = initialRegion
         ? { region: toMapKitCoordinateRegion(initialRegion) }

--- a/src/components/MapProps.tsx
+++ b/src/components/MapProps.tsx
@@ -6,6 +6,11 @@ import {
 
 export default interface MapProps {
   /**
+   * Custom load method for MapKit JS.
+   */
+  load?: (token: string) => Promise<void>;
+
+  /**
    * The token provided by MapKit JS.
    */
   token: string;

--- a/src/stories/Map.stories.tsx
+++ b/src/stories/Map.stories.tsx
@@ -205,3 +205,43 @@ export const PointOfInterestFilters = () => {
   );
 };
 PointOfInterestFilters.storyName = 'Point of Interest Filter';
+
+export const CustomLoadFunction = () => {
+  const initialRegion: CoordinateRegion = useMemo(() => ({
+    centerLatitude: 40.7538,
+    centerLongitude: -73.986,
+    latitudeDelta: 0.03,
+    longitudeDelta: 0.03,
+  }), []);
+
+  return (
+    <Map
+      load={(customLoadToken) => (
+        new Promise((resolve) => {
+          const element = document.createElement('script');
+          // @ts-ignore-next-line
+          window.initMapKit = () => {
+            // @ts-ignore-next-line
+            delete window.initMapKit;
+            window.mapkit.init({
+              authorizationCallback: (done) => {
+                done(customLoadToken);
+              },
+            });
+            resolve();
+          };
+          element.src = 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.core.js';
+          element.dataset.callback = 'initMapKit';
+          element.dataset.initialToken = customLoadToken;
+          element.dataset.libraries = 'map';
+          element.crossOrigin = 'anonymous';
+          document.head.appendChild(element);
+        })
+      )}
+      token={token}
+      initialRegion={initialRegion}
+      showsMapTypeControl={false}
+    />
+  );
+};
+CustomLoadFunction.storyName = 'Custom `load` Function';


### PR DESCRIPTION
tl;dr
```tsx
// same interface as the internal util/loader module
<Map load={() => new Promise(...)} />
```

This enables the caller to have more control over how and when the mapkit resources are loaded. Instead of supporting more API sruface area in mapkit-react library I thought it made sense to just hand over control at the load point as a "advanced use" option. This could lead to foot-guns if the caller doesn't load the necessary resources and then tries to use a component from the lib that depends on the missing resource. In this case the error messages should be clear enough (mapkit says the resrouce needs to be loaded when using associated APIs). 

Needed this flexibility to support my own desires for optimizing map loading performance https://developer.apple.com/documentation/mapkitjs/loading_the_latest_version_of_mapkit_js#3331749.

My main driver was wanting to optimize map loading as much as possible rendering my own static script tag and using `async` and `fetchpriority` attributes which aren't possible when loading the script on demand.