### PR TITLE
add types reference to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "module": "dist/mapkit-react.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/mapkit-react.js",
       "require": "./dist/mapkit-react.umd.js"
     }


### PR DESCRIPTION
Typescript's "bundler" module resolution allows TS to find the type declaration file in package.json. The "types" directive has been replaced by the "exports" directive in package.json.

Relevant issue: https://github.com/microsoft/TypeScript/issues/52363

This PR just adds a "types" module path to the "exports" field on the package.json. If we ever plan to export two files (.mjs and .cjs), then we will have to create a set of type definitions for each.