### PR TITLE
Fix POI filter behavior on initial load

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -200,7 +200,7 @@ const Map = React.forwardRef<mapkit.Map | null, React.PropsWithChildren<MapProps
       );
     } else {
       // @ts-ignore
-      map.pointOfInterestFilter = null;
+      delete map.pointOfInterestFilter;
     }
   }, [map, includedPOICategories, excludedPOICategories]);
 


### PR DESCRIPTION
See #36 

Fixes broken behavior of `showsPointsOfInterest (false)`