### PR TITLE
Bugfix for custom Callout

### DIFF
--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -223,48 +223,46 @@ export default function Annotation({
   forwardMapkitEvent(annotation, 'drag-end', onDragEnd, dragEndParameters);
   forwardMapkitEvent(annotation, 'dragging', onDragging, draggingParameters);
 
-  if (calloutEnabled) {
-    return (
-      <>
-        {calloutContent !== undefined && createPortal(
+  return (
+    <>
+      {createPortal(
+        <div style={{ display: 'none' }}>
+          {(calloutContent !== undefined) && (
           <CalloutContainer
             ref={calloutContentRef}
             type="content"
           >
             {calloutContent}
-          </CalloutContainer>,
-          document.body,
-        )}
-        {calloutLeftAccessory !== undefined && createPortal(
+          </CalloutContainer>
+          )}
+          {(calloutLeftAccessory !== undefined) && (
           <CalloutContainer
             ref={calloutLeftAccessoryRef}
             type="left"
           >
             {calloutLeftAccessory}
-          </CalloutContainer>,
-          document.body,
-        )}
-        {calloutRightAccessory !== undefined && createPortal(
+          </CalloutContainer>
+          )}
+          {(calloutRightAccessory !== undefined) && (
           <CalloutContainer
             ref={calloutRightAccessoryRef}
             type="right"
           >
             {calloutRightAccessory}
-          </CalloutContainer>,
-          document.body,
-        )}
-        {calloutElement !== undefined && createPortal(
+          </CalloutContainer>
+          )}
+          {(calloutElement !== undefined) && (
           <CalloutContainer
             ref={calloutElementRef}
             type="container"
           >
             {calloutElement}
-          </CalloutContainer>,
-          document.body,
-        )}
-        {createPortal(children, contentEl)}
-      </>
-    );
-  }
-  return createPortal(children, contentEl);
+          </CalloutContainer>
+          )}
+        </div>,
+        document.body,
+      )}
+      {createPortal(children, contentEl)}
+    </>
+  );
 }

--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -235,47 +235,41 @@ export default function Marker({
   forwardMapkitEvent(marker, 'drag-end', onDragEnd, dragEndParameters);
   forwardMapkitEvent(marker, 'dragging', onDragging, draggingParameters);
 
-  if (calloutEnabled) {
-    return (
-      <>
-        {calloutContent !== undefined && createPortal(
-          <CalloutContainer
-            ref={calloutContentRef}
-            type="content"
-          >
-            {calloutContent}
-          </CalloutContainer>,
-          document.body,
-        )}
-        {calloutLeftAccessory !== undefined && createPortal(
-          <CalloutContainer
-            ref={calloutLeftAccessoryRef}
-            type="left"
-          >
-            {calloutLeftAccessory}
-          </CalloutContainer>,
-          document.body,
-        )}
-        {calloutRightAccessory !== undefined && createPortal(
-          <CalloutContainer
-            ref={calloutRightAccessoryRef}
-            type="right"
-          >
-            {calloutRightAccessory}
-          </CalloutContainer>,
-          document.body,
-        )}
-        {calloutElement !== undefined && createPortal(
-          <CalloutContainer
-            ref={calloutElementRef}
-            type="container"
-          >
-            {calloutElement}
-          </CalloutContainer>,
-          document.body,
-        )}
-      </>
-    );
-  }
-  return null;
+  return createPortal(
+    <div style={{ display: 'none' }}>
+      {(calloutContent !== undefined) && (
+      <CalloutContainer
+        ref={calloutContentRef}
+        type="content"
+      >
+        {calloutContent}
+      </CalloutContainer>
+      )}
+      {(calloutLeftAccessory !== undefined) && (
+      <CalloutContainer
+        ref={calloutLeftAccessoryRef}
+        type="left"
+      >
+        {calloutLeftAccessory}
+      </CalloutContainer>
+      )}
+      {(calloutRightAccessory !== undefined) && (
+      <CalloutContainer
+        ref={calloutRightAccessoryRef}
+        type="right"
+      >
+        {calloutRightAccessory}
+      </CalloutContainer>
+      )}
+      {(calloutElement !== undefined) && (
+      <CalloutContainer
+        ref={calloutElementRef}
+        type="container"
+      >
+        {calloutElement}
+      </CalloutContainer>
+      )}
+    </div>,
+    document.body,
+  );
 }

--- a/src/stories/Marker.stories.tsx
+++ b/src/stories/Marker.stories.tsx
@@ -201,7 +201,9 @@ export const MarkerClustering = () => {
 MarkerClustering.storyName = 'Clustering three markers into one';
 
 function CustomCalloutElement(
-  { title, subtitle, url }: { title: string, subtitle: string, url: string },
+  {
+    title, subtitle, url, onClick,
+  }: { title: string, subtitle: string, url: string },
 ) {
   return (
     <div className="landmark">
@@ -209,12 +211,14 @@ function CustomCalloutElement(
       <section>
         <p>{subtitle ?? ''}</p>
         <p><a href={url} target="_blank" rel="noreferrer">Website</a></p>
+        <button type="button" onClick={onClick}>Hide Map</button>
       </section>
     </div>
   );
 }
 
 export const CustomMarkerCallout = () => {
+  const [mapVisible, setMapVisible] = useState(true);
   const initialRegion: CoordinateRegion = useMemo(() => ({
     centerLatitude: 46.20738751546706,
     centerLongitude: 6.155891756231,
@@ -222,19 +226,21 @@ export const CustomMarkerCallout = () => {
     longitudeDelta: 0.015,
   }), []);
 
-  return (
-    <Map token={token} initialRegion={initialRegion}>
-      <Marker
-        latitude={46.20738751546706}
-        longitude={6.155891756231}
-        title="Jet d’eau"
-        subtitle="Iconic landmark of Geneva"
-        calloutElement={<CustomCalloutElement title="Jet d’eau" subtitle="Iconic landmark of Geneva" url="https://en.wikipedia.org/wiki/Jet_d%27Eau" />}
-        calloutEnabled
-        calloutOffsetX={-148}
-        calloutOffsetY={-78}
-      />
-    </Map>
+  return (mapVisible
+    ? (
+      <Map token={token} initialRegion={initialRegion}>
+        <Marker
+          latitude={46.20738751546706}
+          longitude={6.155891756231}
+          title="Jet d’eau"
+          subtitle="Iconic landmark of Geneva"
+          calloutElement={<CustomCalloutElement title="Jet d’eau" subtitle="Iconic landmark of Geneva" url="https://en.wikipedia.org/wiki/Jet_d%27Eau" onClick={() => setMapVisible(false)} />}
+          calloutEnabled
+          calloutOffsetX={-148}
+          calloutOffsetY={-78}
+        />
+      </Map>
+    ) : <button type="button" onClick={() => setMapVisible(true)}>Show map</button>
   );
 };
 CustomMarkerCallout.storyName = 'Marker with custom callout element';

--- a/src/stories/Marker.stories.tsx
+++ b/src/stories/Marker.stories.tsx
@@ -202,7 +202,7 @@ MarkerClustering.storyName = 'Clustering three markers into one';
 
 function CustomCalloutElement(
   {
-    title, subtitle, url, onClick,
+    title, subtitle, url,
   }: { title: string, subtitle: string, url: string },
 ) {
   return (
@@ -211,14 +211,12 @@ function CustomCalloutElement(
       <section>
         <p>{subtitle ?? ''}</p>
         <p><a href={url} target="_blank" rel="noreferrer">Website</a></p>
-        <button type="button" onClick={onClick}>Hide Map</button>
       </section>
     </div>
   );
 }
 
 export const CustomMarkerCallout = () => {
-  const [mapVisible, setMapVisible] = useState(true);
   const initialRegion: CoordinateRegion = useMemo(() => ({
     centerLatitude: 46.20738751546706,
     centerLongitude: 6.155891756231,
@@ -226,21 +224,19 @@ export const CustomMarkerCallout = () => {
     longitudeDelta: 0.015,
   }), []);
 
-  return (mapVisible
-    ? (
-      <Map token={token} initialRegion={initialRegion}>
-        <Marker
-          latitude={46.20738751546706}
-          longitude={6.155891756231}
-          title="Jet d’eau"
-          subtitle="Iconic landmark of Geneva"
-          calloutElement={<CustomCalloutElement title="Jet d’eau" subtitle="Iconic landmark of Geneva" url="https://en.wikipedia.org/wiki/Jet_d%27Eau" onClick={() => setMapVisible(false)} />}
-          calloutEnabled
-          calloutOffsetX={-148}
-          calloutOffsetY={-78}
-        />
-      </Map>
-    ) : <button type="button" onClick={() => setMapVisible(true)}>Show map</button>
+  return (
+    <Map token={token} initialRegion={initialRegion}>
+      <Marker
+        latitude={46.20738751546706}
+        longitude={6.155891756231}
+        title="Jet d’eau"
+        subtitle="Iconic landmark of Geneva"
+        calloutElement={<CustomCalloutElement title="Jet d’eau" subtitle="Iconic landmark of Geneva" url="https://en.wikipedia.org/wiki/Jet_d%27Eau" />}
+        calloutEnabled
+        calloutOffsetX={-148}
+        calloutOffsetY={-78}
+      />
+    </Map>
   );
 };
 CustomMarkerCallout.storyName = 'Marker with custom callout element';


### PR DESCRIPTION
Fixes #56 and fixes #57

This bug fixes a behavior where React would throw an error on component unmount. Also it fixes an issue where the callout would be visible although not being clicked at the end of the page.

One thing I would like to challenge while merging this PR. For the implementation I had before I attached the annotation callouts within their html element in the page whereas I attached those of the marker to the document body. With this fix, I attached both annotations to the document body, however, I would like to challenge this behavior and would be interested in your opinion on this @Nicolapps 