### PR TITLE
Fix Marker collision mode

### DIFF
--- a/src/components/Marker.tsx
+++ b/src/components/Marker.tsx
@@ -161,9 +161,9 @@ export default function Marker({
     if (!marker) return;
 
     if (collisionMode === 'Circle') {
-      marker.collisionMode = mapkit.MarkerAnnotation.CollisionMode.Circle;
+      marker.collisionMode = mapkit.Annotation.CollisionMode.Circle;
     } else if (collisionMode === 'Rectangle') {
-      marker.collisionMode = mapkit.MarkerAnnotation.CollisionMode.Rectangle;
+      marker.collisionMode = mapkit.Annotation.CollisionMode.Rectangle;
     } else {
       // @ts-ignore
       delete marker.collisionMode;


### PR DESCRIPTION
I figured out collision mode seems to be in the storybook "Marker - clustering three marker into one"

<img width="805" alt="image" src="https://github.com/Nicolapps/mapkit-react/assets/49103409/3198128a-586a-4e6b-bd2c-38fab4b98753">

So I replaced the `markerAnnotation.collisionMode` type with the `annotation.collisionMode` type which appears to fix the issue.