### PR TITLE
Exposing MapContext

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,5 @@ export type {
   MapInteractionEvent,
   UserLocationChangeEvent, UserLocationError, UserLocationErrorEvent,
 } from './events';
+
+export { default as MapContext } from './context/MapContext';


### PR DESCRIPTION
Hi!

I've been struggling to access some specific MapKit features, so I thought it would be reasonable to provide a way to access MapKit directly. After some investigation, I found that this can be managed using the MapContext.

I've proposed a non-breaking change to expose it.