### PR TITLE
build: externalize react/jsx-runtime and react-dom/client

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       fileName: 'mapkit-react',
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react/jsx-runtime', 'react-dom', 'react-dom/client'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
Optimizes bundeling sizes, because at the moment react/jsx-runtime is being bundled unnecessary leading to a overhead in production, by externalizing react/jsx-runtime and also for the future react-dom/client, should reduce the file size by about 10kb

See https://unpkg.com/mapkit-react@1.15.2/dist/mapkit-react.js -> has references to ReactCurrentDispatcher and react/jsx-runtime

Also referred to / would have fixed #71 

---

The reason why it breakes is that __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED were updated in react 19, which leads to a problem and react version mismatch, because __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED is undefined, and nextjs15 is using react 19 rc, and as react/jsx-runtime is bundled with react 18 version, there is still this unnecessary reference.

It is not necessary to bundle react/jsx-runtime, therefore this PR removes it, leading to a way smaller bundle, because we expect react / the runtime when using this package, which is always already in the bundle.